### PR TITLE
Adding WebDriverManager to avoid having to download each browser locally.

### DIFF
--- a/configs/config.properties
+++ b/configs/config.properties
@@ -1,13 +1,3 @@
-!--Web Driver Paths
-chromeDriverPath=C:\\selenium-drivers\\chrome-driver\\chromedriver.exe
-firefoxDriverPath=C:\\selenium-drivers\\firefox-driver\\geckodriver.exe
-internetExplorerDriverPath=C:\\selenium-drivers\\internet-explorer-driver\\IEDriverServer.exe
-
-!--Web Drivers
-useChromeDriver=webdriver.chrome.driver
-useFirefoxDriver=webdriver.gecko.driver
-useInternetExplorerDriver=webdriver.ie.driver
-
 !--Chrome Driver Options
 chromeDriverMaximizedOption=start-maximized
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>groupId</groupId>
-    <artifactId>TKJavaProject</artifactId>
+    <artifactId>Evertest-UI</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <build>
@@ -94,6 +94,13 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <version>3.141.59</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>3.6.1</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/src/test/java/dataProvider/ConfigFileReader.java
+++ b/src/test/java/dataProvider/ConfigFileReader.java
@@ -35,24 +35,6 @@ public class ConfigFileReader {
         else throw new RuntimeException("Parameter value not specified in the testng.xml file.");
     }
 
-    public String getChromeDriverPath(){
-        String driverPath = properties.getProperty("chromeDriverPath");
-        if(driverPath!= null) return driverPath;
-        else throw new RuntimeException("driverPath not specified in the Configuration.properties file.");
-    }
-
-    public String getFirefoxDriverPath(){
-        String driverPath = properties.getProperty("firefoxDriverPath");
-        if(driverPath!= null) return driverPath;
-        else throw new RuntimeException("driverPath not specified in the Configuration.properties file.");
-    }
-
-    public String getInternetExplorerDriverPath(){
-        String driverPath = properties.getProperty("internetExplorerDriverPath");
-        if(driverPath!= null) return driverPath;
-        else throw new RuntimeException("driverPath not specified in the Configuration.properties file.");
-    }
-
     public long getImplicitlyWait() {
         String implicitlyWait = properties.getProperty("implicitWaitTime");
         if(implicitlyWait != null) return Long.parseLong(implicitlyWait);
@@ -75,21 +57,4 @@ public class ConfigFileReader {
         else throw new RuntimeException("Driver Option not specified in the Configuration.properties file.");
     }
 
-    public String useChromeDriver() {
-        String url = properties.getProperty("useChromeDriver");
-        if(url != null) return url;
-        else throw new RuntimeException("Web Driver not specified in the Configuration.properties file.");
-    }
-
-    public String useFirefoxDriver() {
-        String url = properties.getProperty("useFirefoxDriver");
-        if(url != null) return url;
-        else throw new RuntimeException("Web Driver not specified in the Configuration.properties file.");
-    }
-
-    public String useInternetExplorerDriver() {
-        String url = properties.getProperty("useInternetExplorerDriver");
-        if(url != null) return url;
-        else throw new RuntimeException("Web Driver not specified in the Configuration.properties file.");
-    }
 }

--- a/src/test/java/steps/Hook.java
+++ b/src/test/java/steps/Hook.java
@@ -4,6 +4,7 @@ import base.BaseUtil;
 import cucumber.api.Scenario;
 import cucumber.api.java.*;
 import dataProvider.ConfigFileReader;
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -29,7 +30,7 @@ public class Hook extends BaseUtil {
         String browser = configFileReader.getTestNGParameterValue("browserName");
         System.out.println("\nPreparing Browser...");
         if (browser.equals("Chrome")) {
-            System.setProperty(configFileReader.useChromeDriver(), configFileReader.getChromeDriverPath());
+            WebDriverManager.chromedriver().setup();
             base.Options = new ChromeOptions();
             base.Options.addArguments(configFileReader.getChromeDriverMaximizedOption());
             base.Driver = new ChromeDriver(base.Options);
@@ -37,17 +38,16 @@ public class Hook extends BaseUtil {
         }
 
         else if (browser.equals("Firefox")) {
-            System.setProperty(configFileReader.useFirefoxDriver(), configFileReader.getFirefoxDriverPath());
+            WebDriverManager.firefoxdriver().setup();
             base.Driver = new FirefoxDriver();
             base.Wait = new WebDriverWait(base.Driver, configFileReader.getImplicitlyWait());
         }
         else if (browser.equals("Internet Explorer")){
-            System.setProperty(configFileReader.useInternetExplorerDriver(), configFileReader.getInternetExplorerDriverPath());
+            WebDriverManager.iedriver().setup();
             base.ieOptions = new InternetExplorerOptions();
             base.ieOptions.setCapability(InternetExplorerDriver.NATIVE_EVENTS, false);
             base.Driver = new InternetExplorerDriver(base.ieOptions);
             base.Wait = new WebDriverWait(base.Driver, configFileReader.getImplicitlyWait());
-            base.Driver.manage().deleteAllCookies();
             base.Driver.manage().window().maximize();
         }
         System.out.println("\nBrowser '"+browser+"' is ready!");


### PR DESCRIPTION
-With WebDriverManager dependency, there will be no need to download the driver.exe file for each browser. The library looks for them remotely in real time. Now anyone who clones the Repo locally will be able to execute the TCs against any browser without any particular extra work.
-Removing innecesary methods to read driver.exe file paths and properties (configFileReader.java)
-Removing paths and properties of each browser driver (conifg.properties)
-Adding WebDriverManager dependency and updating project name (pom.xml)
-Adding browser drivers setup using new WebDriverManager dependency (Hook.java)