### PR TITLE
Adding .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.iml
 .idea/*
 target/*
 */target/*


### PR DESCRIPTION
The idea is to use this file to avoid pushing files which are created by maven and by the solution when running. Only code should be pushed.